### PR TITLE
Fixed notifications in android Oreo

### DIFF
--- a/app/src/androidTest/kotlin/com/wabadaba/dziennik/EspressoDaggerMockRule.kt
+++ b/app/src/androidTest/kotlin/com/wabadaba/dziennik/EspressoDaggerMockRule.kt
@@ -8,6 +8,6 @@ class EspressoDaggerMockRule : DaggerMockRule<MainComponent>(
         MainComponent::class.java,
         ApplicationModule(BaseInstrumentedTest.getApp())) {
     init {
-        set { component -> BaseInstrumentedTest.getApp().mainComponent = component }
+        set { component -> MainApplication.mainComponent = component }
     }
 }

--- a/app/src/main/kotlin/com/wabadaba/dziennik/MainApplication.kt
+++ b/app/src/main/kotlin/com/wabadaba/dziennik/MainApplication.kt
@@ -10,8 +10,9 @@ import com.wabadaba.dziennik.di.MainComponent
 import javax.inject.Inject
 
 open class MainApplication : MultiDexApplication() {
-
-    lateinit var mainComponent: MainComponent
+    companion object {
+        lateinit var mainComponent: MainComponent
+    }
 
     @Inject
     lateinit var gcmRegistrationManager: LibrusGCMRegistrationManager

--- a/app/src/main/kotlin/com/wabadaba/dziennik/api/notification/LibrusGcmListenerService.kt
+++ b/app/src/main/kotlin/com/wabadaba/dziennik/api/notification/LibrusGcmListenerService.kt
@@ -1,50 +1,57 @@
 package com.wabadaba.dziennik.api.notification
 
-import android.app.NotificationManager
 import android.app.PendingIntent
-import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.preference.PreferenceManager
 import android.support.v4.app.NotificationCompat
 import com.google.android.gms.gcm.GcmListenerService
+import com.wabadaba.dziennik.MainApplication
 import com.wabadaba.dziennik.R
 import com.wabadaba.dziennik.ui.MainActivity
+import javax.inject.Inject
 
 
 @Suppress("DEPRECATION")
 class LibrusGcmListenerService : GcmListenerService() {
-    override fun onMessageReceived(p0: String, data: Bundle) {
+    @Inject lateinit var notificationHelper : NotificationSender
 
+    override fun onMessageReceived(p0: String, data: Bundle) {
+        MainApplication.mainComponent.inject(this)
+
+        if (checkNotificationsEnabled()) {
+            val message = data.getString("message")
+            val user = data.getString("userId")
+
+            val intent = Intent(this, MainActivity::class.java)
+            val pendingIntent = PendingIntent.getActivity(
+                    this,
+                    0,
+                    intent,
+                    PendingIntent.FLAG_UPDATE_CURRENT
+            )
+
+            val notification = NotificationCompat.Builder(this, NotificationSender.NOTIFICATION_CHANNEL_ID)
+                    .setSmallIcon(R.drawable.ic_school_black_24dp)
+                    .setContentTitle(message)
+                    .setContentText(user)
+                    .setContentIntent(pendingIntent)
+                    .setAutoCancel(true)
+                    .setPriority(NotificationCompat.PRIORITY_HIGH)
+                    .build()
+
+            notificationHelper.updateNotification(System.currentTimeMillis().toInt(), notification)
+        }
+    }
+
+    private fun checkNotificationsEnabled() : Boolean {
         val prefs = PreferenceManager.getDefaultSharedPreferences(this)
         if (!prefs.getBoolean("enable_notifications", true)) {
             println("received message but notifications are disabled")
-            return
+            return true
         }
 
         println("received message, sending notification...")
-
-        val message = data.getString("message")
-        val user = data.getString("userId")
-
-        val intent = Intent(this, MainActivity::class.java)
-        val pendingIntent = PendingIntent.getActivity(
-                this,
-                0,
-                intent,
-                PendingIntent.FLAG_UPDATE_CURRENT
-        )
-
-        val notification = NotificationCompat.Builder(this)
-                .setSmallIcon(R.drawable.ic_school_black_24dp)
-                .setContentTitle(message)
-                .setContentText(user)
-                .setContentIntent(pendingIntent)
-                .setAutoCancel(true)
-                .setPriority(NotificationCompat.PRIORITY_HIGH)
-                .build()
-
-        val notifyManager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-        notifyManager.notify(System.currentTimeMillis().toInt(), notification)
+        return false
     }
 }

--- a/app/src/main/kotlin/com/wabadaba/dziennik/api/notification/NotificationSender.kt
+++ b/app/src/main/kotlin/com/wabadaba/dziennik/api/notification/NotificationSender.kt
@@ -1,0 +1,38 @@
+package com.wabadaba.dziennik.api.notification
+
+import android.app.Notification
+import android.app.NotificationManager
+import android.app.NotificationChannel
+import android.content.Context
+import android.os.Build
+import android.support.annotation.RequiresApi
+
+
+class NotificationSender(private val context: Context) {
+    private val notificationManager by lazy { context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager }
+
+    companion object {
+        val NOTIFICATION_CHANNEL_ID = "com.wabadaba.dziennik.notifications"
+        val NOTIFICATION_TAG = "com.wabadaba.dziennik"
+    }
+
+    init {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            createChannels()
+        }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    private fun createChannels() {
+        val notificationChannel = NotificationChannel(NOTIFICATION_CHANNEL_ID,
+                NOTIFICATION_CHANNEL_ID, NotificationManager.IMPORTANCE_HIGH)
+        notificationChannel.enableLights(true)
+        notificationChannel.setShowBadge(true)
+        notificationManager.createNotificationChannel(notificationChannel)
+    }
+
+    fun updateNotification(id : Int, notification: Notification) {
+        notificationManager.notify(NOTIFICATION_TAG, id, notification)
+    }
+
+}

--- a/app/src/main/kotlin/com/wabadaba/dziennik/di/ApplicationModule.kt
+++ b/app/src/main/kotlin/com/wabadaba/dziennik/di/ApplicationModule.kt
@@ -1,11 +1,13 @@
 package com.wabadaba.dziennik.di
 
 import android.app.Application
+import android.app.NotificationManager
 import android.content.Context
 import android.content.SharedPreferences
 import android.preference.PreferenceManager
 import com.wabadaba.dziennik.api.*
 import com.wabadaba.dziennik.api.notification.LibrusGCMRegistrationManager
+import com.wabadaba.dziennik.api.notification.NotificationSender
 import com.wabadaba.dziennik.db.DatabaseManager
 import com.wabadaba.dziennik.ui.FragmentRepository
 import com.wabadaba.dziennik.ui.GPServicesChecker
@@ -67,4 +69,7 @@ class ApplicationModule(private val mainApplication: Application) {
     @Provides
     @Singleton
     fun provideGPServicesChecker(): GPServicesChecker = GPServicesChecker()
+
+    @Provides
+    fun provideNotificationHelper(context: Context) = NotificationSender(context)
 }

--- a/app/src/main/kotlin/com/wabadaba/dziennik/di/MainComponent.kt
+++ b/app/src/main/kotlin/com/wabadaba/dziennik/di/MainComponent.kt
@@ -1,6 +1,7 @@
 package com.wabadaba.dziennik.di
 
 import com.wabadaba.dziennik.MainApplication
+import com.wabadaba.dziennik.api.notification.LibrusGcmListenerService
 import com.wabadaba.dziennik.ui.MainActivity
 import com.wabadaba.dziennik.ui.SettingsFragment
 import com.wabadaba.dziennik.ui.announcements.AnnouncementsFragment
@@ -24,4 +25,5 @@ interface MainComponent {
     fun inject(settingsFragment: SettingsFragment)
     fun inject(eventsFragment: EventsFragment)
     fun inject(announcementsFragment: AnnouncementsFragment)
+    fun inject(librusGcmListenerService: LibrusGcmListenerService)
 }

--- a/app/src/main/kotlin/com/wabadaba/dziennik/ui/MainActivity.kt
+++ b/app/src/main/kotlin/com/wabadaba/dziennik/ui/MainActivity.kt
@@ -101,8 +101,7 @@ class MainActivity : AppCompatActivity() {
         title = getString(R.string.app_name)
         setSupportActionBar(toolbar_main)
 
-        val mainApplication = applicationContext as MainApplication
-        mainApplication.mainComponent.inject(this)
+        MainApplication.mainComponent.inject(this)
 
         viewModel = ViewModelProviders.of(this, viewModelFactory).get(MainViewModel::class.java)
 

--- a/app/src/main/kotlin/com/wabadaba/dziennik/ui/SettingsFragment.kt
+++ b/app/src/main/kotlin/com/wabadaba/dziennik/ui/SettingsFragment.kt
@@ -15,8 +15,7 @@ class SettingsFragment : PreferenceFragmentCompat() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        val mainApplication = activity.applicationContext as MainApplication
-        mainApplication.mainComponent.inject(this)
+        MainApplication.mainComponent.inject(this)
 
         val defaultFragmentPreference: ListPreference = findPreference("defaultFragment") as ListPreference
 

--- a/app/src/main/kotlin/com/wabadaba/dziennik/ui/announcements/AnnouncementsFragment.kt
+++ b/app/src/main/kotlin/com/wabadaba/dziennik/ui/announcements/AnnouncementsFragment.kt
@@ -27,8 +27,7 @@ class AnnouncementsFragment : Fragment() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val mainApplication = activity.application as MainApplication
-        mainApplication.mainComponent.inject(this)
+        MainApplication.mainComponent.inject(this)
     }
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {

--- a/app/src/main/kotlin/com/wabadaba/dziennik/ui/attendance/AttendancesFragment.kt
+++ b/app/src/main/kotlin/com/wabadaba/dziennik/ui/attendance/AttendancesFragment.kt
@@ -31,8 +31,7 @@ class AttendancesFragment : Fragment() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val mainApplication = activity.application as MainApplication
-        mainApplication.mainComponent.inject(this)
+        MainApplication.mainComponent.inject(this)
     }
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {

--- a/app/src/main/kotlin/com/wabadaba/dziennik/ui/events/EventsFragment.kt
+++ b/app/src/main/kotlin/com/wabadaba/dziennik/ui/events/EventsFragment.kt
@@ -28,8 +28,7 @@ class EventsFragment : Fragment() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val mainApplication = activity.application as MainApplication
-        mainApplication.mainComponent.inject(this)
+        MainApplication.mainComponent.inject(this)
     }
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {

--- a/app/src/main/kotlin/com/wabadaba/dziennik/ui/grades/GradesFragment.kt
+++ b/app/src/main/kotlin/com/wabadaba/dziennik/ui/grades/GradesFragment.kt
@@ -32,8 +32,7 @@ class GradesFragment : Fragment() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val mainApplication = activity.application as MainApplication
-        mainApplication.mainComponent.inject(this)
+        MainApplication.mainComponent.inject(this)
     }
 
     override fun onCreateView(inflater: LayoutInflater?, container: ViewGroup?, savedInstanceState: Bundle?)

--- a/app/src/main/kotlin/com/wabadaba/dziennik/ui/login/LoginActivity.kt
+++ b/app/src/main/kotlin/com/wabadaba/dziennik/ui/login/LoginActivity.kt
@@ -27,7 +27,7 @@ class LoginActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        (applicationContext as MainApplication).mainComponent.inject(this)
+        MainApplication.mainComponent.inject(this)
         setContentView(R.layout.activity_login)
 
         logInButton.setOnClickListener {

--- a/app/src/main/kotlin/com/wabadaba/dziennik/ui/timetable/TimetableFragment.kt
+++ b/app/src/main/kotlin/com/wabadaba/dziennik/ui/timetable/TimetableFragment.kt
@@ -35,8 +35,7 @@ class TimetableFragment : Fragment() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val mainApplication = activity.application as MainApplication
-        mainApplication.mainComponent.inject(this)
+        MainApplication.mainComponent.inject(this)
     }
 
     override fun onCreateView(inflater: LayoutInflater?, container: ViewGroup?, savedInstanceState: Bundle?)

--- a/versions.gradle
+++ b/versions.gradle
@@ -1,7 +1,7 @@
 ext {
     versions = [
             buildTools      : '26.0.2',
-            androidPlugin   : '3.0.0-beta7',
+            androidPlugin   : '3.0.0-rc1',
             androidMultidex : '1.0.2',
             google_services : '3.1.0',
             play_services   : '11.4.2',


### PR DESCRIPTION
Some users reported problems with notifications not showing. It happens because we use android sdk 26, which requires notification channels.
- Moved dagger injector to compation object
- Created new `NotificationHelper`